### PR TITLE
Add widget for Dabaghi & Der Kiureghian (2018) model

### DIFF
--- a/EE-UQ.pri
+++ b/EE-UQ.pri
@@ -17,7 +17,8 @@ SOURCES += \
     $$PWD/StandardEarthquakeEDP.cpp \
     $$PWD/StochasticMotionInput/src/StochasticMotionInputWidget.cpp \
     $$PWD/StochasticMotionInput/src/StochasticModelWidget.cpp \
-    $$PWD/StochasticMotionInput/src/VlachosEtAlModel.cpp 
+    $$PWD/StochasticMotionInput/src/VlachosEtAlModel.cpp \
+    $$PWD/StochasticMotionInput/src/DabaghiDerKiureghianPulse.cpp     
 
 HEADERS  += \
     $$PWD/UniformMotionInput.h \
@@ -29,7 +30,8 @@ HEADERS  += \
     $$PWD/ExistingPEER_Events.h \
     $$PWD/StochasticMotionInput/include/StochasticMotionInputWidget.h \
     $$PWD/StochasticMotionInput/include/StochasticModelWidget.h \    
-    $$PWD/StochasticMotionInput/include/VlachosEtAlModel.h 
+    $$PWD/StochasticMotionInput/include/VlachosEtAlModel.h \
+    $$PWD/StochasticMotionInput/include/DabaghiDerKiureghianPulse.h     
 
 RESOURCES += \
     images.qrc \

--- a/StochasticMotionInput/include/DabaghiDerKiureghianPulse.h
+++ b/StochasticMotionInput/include/DabaghiDerKiureghianPulse.h
@@ -1,0 +1,133 @@
+#ifndef _DABAGHI_DER_KIUREGHIAN_PULSE_H
+#define _DABAGHI_DER_KIUREGHIAN_PULSE_H
+
+/* *****************************************************************************
+Copyright (c) 2016-2017, The Regents of the University of California (Regents).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS 
+PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, 
+UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+*************************************************************************** */
+
+// Written: mhgardner
+#include <LineEditRV.h>
+#include <QFormLayout>
+#include <QJsonObject>
+#include <QLabel>
+#include <QLineEdit>
+#include <QRadioButton>
+#include <QSpinBox>
+#include <QString>
+#include <QWidget>
+#include <RandomVariablesContainer.h>
+#include <SimCenterWidget.h>
+#include "StochasticModelWidget.h"
+
+// Forward declarations
+class LineEditRV;
+class QFormLayout;
+class QJsonObject;
+class QLabel;
+class QLineEdit;
+class QRadioButton;
+class QSpinBox;
+class QString;
+class QWidget;
+class RandomVariablesContainer;
+
+/**
+ * Widget for inputting parameters for stochastic earthquake time history
+ * generation model
+ */
+class DabaghiDerKiureghianPulse : public StochasticModelWidget {
+  Q_OBJECT
+ public:
+  /**
+   * @constructor Construct new stochastic model input widget
+   * @param[in, out] random_variables Widget to store random variables to
+   * @param[in, out] parent Pointer to parent widget. Defaults to nullptr.
+   */
+  explicit DabaghiDerKiureghianPulse(RandomVariablesContainer* random_variables,
+                                     QWidget* parent = nullptr);
+
+  /**
+   * @destructor Virtual desctructor for stochastic model input widget
+   */
+  virtual ~DabaghiDerKiureghianPulse(){};
+
+  /**
+   * Instantiate stochastic motion input widget from input JSON object
+   * @param[in] rvObject JSON object containing input information
+   * @return Returns true if successful, false otherwise
+   */
+  bool inputFromJSON(QJsonObject& rvObject) override;
+
+  /**
+   * Write all current class data to JSON required to reconstruct class
+   * @param[in, out] rvObject JSON object to write output to
+   * @return Returns true if successful, false otherwise
+   */
+  bool outputToJSON(QJsonObject& rvObject) override;
+
+ public slots:
+  /**
+   * Update ability to provide seed based on changed status of radio button
+   * @param[in] checked Current status of radio button for providing seed
+   */
+  void provideSeed(const bool& checked);
+
+ protected:
+  QLabel* model_description_; /**< Brief description of model indicating relevant
+				 paper where more information can be found describing
+				 model in greater detail */
+  QComboBox* faulting_;       /**< Selection for type of faulting */
+  QComboBox* sim_type_;       /**< Selection of pulse-typ of simulation */
+  LineEditRV* moment_magnitude_; /**< Moment magnitude of event */
+  LineEditRV* depth_to_rupt_; /**< Depth to the top of hte rupture plane in km
+                                */
+  LineEditRV* rupture_dist_;   /**< Closest-to-site rupture distance in km */
+  LineEditRV* vs30_;   /**< Average shear-wave velocity for the upper 30-m depth
+                          (Vs30) */
+  LineEditRV* s_or_d_; /**< Directivity parameter s or d (km)--input the larger
+                          of the two */
+  LineEditRV* theta_or_phi_; /**< Directivity ange parameter theta or phi
+                                (degrees)--input corresponding value to s or d
+                              */
+  QRadioButton* truncate_;   /**< Radio button to indicate whether synthetic
+                                motion should be truncated and baseline corrected
+                              */
+  QSpinBox* seed_;           /**< Value to use as seed for motion generation */
+  QRadioButton* use_seed_;   /**< Radio button to indicate whether specific seed
+                                value should be used */
+  QFormLayout* parameters_;  /**< Widget for inputting model parameters */
+};
+
+#endif  // _DABAGHI_DER_KIUREGHIAN_PULSE_H

--- a/StochasticMotionInput/src/DabaghiDerKiureghianPulse.cpp
+++ b/StochasticMotionInput/src/DabaghiDerKiureghianPulse.cpp
@@ -113,7 +113,9 @@ DabaghiDerKiureghianPulse::DabaghiDerKiureghianPulse(
   QHBoxLayout* seed_layout = new QHBoxLayout();
   QHBoxLayout* truncate_layout = new QHBoxLayout();  
   QHBoxLayout* parameters_layout = new QHBoxLayout();
-
+  QHBoxLayout* faulting_layout = new QHBoxLayout();
+  QHBoxLayout* sim_type_layout = new QHBoxLayout();  
+  
   // Add widgets to layouts and layouts to this
   seed_layout->addWidget(use_seed_);
   seed_layout->addWidget(seed_);
@@ -122,7 +124,13 @@ DabaghiDerKiureghianPulse::DabaghiDerKiureghianPulse(
   truncate_layout->addStretch();  
   parameters_layout->addLayout(parameters_);
   parameters_layout->addStretch();
+  faulting_layout->addWidget(faulting_);
+  faulting_layout->addStretch();
+  sim_type_layout->addWidget(sim_type_);
+  sim_type_layout->addStretch();
   layout->addWidget(model_description_);
+  layout->addLayout(faulting_layout);
+  layout->addLayout(sim_type_layout);
   layout->addLayout(parameters_layout);
   layout->addLayout(truncate_layout);
   layout->addLayout(seed_layout);
@@ -137,9 +145,22 @@ DabaghiDerKiureghianPulse::DabaghiDerKiureghianPulse(
 bool DabaghiDerKiureghianPulse::outputToJSON(QJsonObject& jsonObject) {
   bool result = true;
 
-  jsonObject.insert("faultType", faulting_->currentText());
-  jsonObject.insert("simulationType", sim_type_->currentText());
+  auto fault_type = faulting_->currentText();
+  if (fault_type == "Strike-Slip") {
+    jsonObject.insert("faultType", "StrikeSlip");
+  } else if (fault_type == "Reverse and Reverse-Oblique") {
+    jsonObject.insert("faultType", "ReverseAndRevObliq");
+  }
 
+  auto simulation_type = sim_type_->currentText();
+  if (simulation_type == "Pulse-like and no pulse-like") {
+    jsonObject.insert("simulationType", "PulseAndNoPulse");
+  } else if (simulation_type == "Only pulse-like") {
+    jsonObject.insert("simulationType", "Pulse");
+  } else if (simulation_type == "No pulse-like") {
+    jsonObject.insert("simulationType", "NoPulse");
+  }  
+  
   moment_magnitude_->outputToJSON(jsonObject, QString("momentMagnitude"));
   depth_to_rupt_->outputToJSON(jsonObject, QString("depthToRupt"));
   rupture_dist_->outputToJSON(jsonObject, QString("ruptureDist"));
@@ -162,9 +183,24 @@ bool DabaghiDerKiureghianPulse::inputFromJSON(QJsonObject& jsonObject) {
   bool result = true;
 
   QString fault_type = jsonObject["faultType"].toString();
-  faulting_->setCurrentIndex(faulting_->findText(fault_type));
   QString sim_type = jsonObject["simulationType"].toString();
-  sim_type_->setCurrentIndex(sim_type_->findText(sim_type));
+
+  if (fault_type == "StrikeSlip") {
+    faulting_->setCurrentIndex(faulting_->findText("Strike-Slip"));
+  } else if (fault_type == "ReverseAndRevObliq") {
+    faulting_->setCurrentIndex(
+        faulting_->findText("Reverse and Reverse-Oblique"));
+  }
+
+  auto simulation_type = sim_type_->currentText();
+  if (simulation_type == "PulseAndNoPulse") {
+    sim_type_->setCurrentIndex(
+        sim_type_->findText("Pulse-like proportion of motions"));
+  } else if (simulation_type == "Pulse") {
+    sim_type_->setCurrentIndex(sim_type_->findText("Only pulse-like"));
+  } else if (simulation_type == "NoPulse") {
+    sim_type_->setCurrentIndex(sim_type_->findText("No pulse-like"));
+  }
 
   moment_magnitude_->inputFromJSON(jsonObject, QString("momentMagnitude"));
   depth_to_rupt_->inputFromJSON(jsonObject, QString("depthToRupt"));

--- a/StochasticMotionInput/src/DabaghiDerKiureghianPulse.cpp
+++ b/StochasticMotionInput/src/DabaghiDerKiureghianPulse.cpp
@@ -1,0 +1,199 @@
+/* *****************************************************************************
+Copyright (c) 2016-2017, The Regents of the University of California (Regents).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS 
+PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, 
+UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+*************************************************************************** */
+
+// Written: mhgardner
+#include <QComboBox>
+#include <QDebug>
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+#include <QJsonValue>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QLabel>
+#include <QSpinBox>
+#include <QString>
+#include <QVBoxLayout>
+
+#include <RandomVariablesContainer.h>
+#include <SimCenterWidget.h>
+
+#include "DabaghiDerKiureghianPulse.h"
+
+DabaghiDerKiureghianPulse::DabaghiDerKiureghianPulse(
+    RandomVariablesContainer* random_variables, QWidget* parent)
+    : StochasticModelWidget(random_variables, parent) {
+  // Initialize member variables
+  faulting_ = new QComboBox();
+  faulting_->setObjectName("Type of faulting");
+  faulting_->addItem(tr("Strike-Slip"));
+  faulting_->addItem(tr("Reverse and Reverse-Oblique"));
+
+  sim_type_ = new QComboBox();
+  sim_type_->setObjectName("Pulse-like proportion of motions");
+  sim_type_->addItem(tr("Pulse-like and no pulse-like"));  
+  sim_type_->addItem(tr("Only pulse-like"));
+  sim_type_->addItem(tr("No pulse-like"));
+  
+  moment_magnitude_ = new LineEditRV(random_variables);
+  depth_to_rupt_ = new LineEditRV(random_variables);  
+  rupture_dist_ = new LineEditRV(random_variables);
+  vs30_ = new LineEditRV(random_variables);
+  s_or_d_ = new LineEditRV(random_variables);
+  theta_or_phi_ = new LineEditRV(random_variables);  
+  truncate_ = new QRadioButton("Truncate and baseline correct synthetic motion");
+  truncate_->setAutoExclusive(false);
+  truncate_->setChecked(true);  
+  seed_ = new QSpinBox();
+  seed_->setMinimum(1);
+  seed_->setMaximum(2147483647);
+  seed_->setValue(500);  
+  seed_->setEnabled(false);
+  use_seed_ = new QRadioButton("Provide seed value");
+  use_seed_->setAutoExclusive(false);
+  use_seed_->setChecked(false);
+  
+  parameters_ = new QFormLayout();
+  parameters_->addRow(new QLabel(tr("Moment Magnitude")), moment_magnitude_);
+  parameters_->addRow(new QLabel(tr("Depth to Top of Rupture Plane [km]")), depth_to_rupt_);
+  parameters_->addRow(new QLabel(tr("Closest-to-Site Rupture Distance [km]")),
+                      rupture_dist_);
+  parameters_->addRow(
+      new QLabel(tr("Average shear-wave velocity for top 30 meters [m/s]")),
+      vs30_);
+  parameters_->addRow(new QLabel(tr("s or d [km] (Input larger of the two)")),
+                      s_or_d_);
+  parameters_->addRow(
+      new QLabel(
+          tr("Theta or Phi [degrees] (Input value corresponding to s or d)")),
+      theta_or_phi_);
+
+  // Add description label
+  model_description_ = new QLabel(
+      tr("This model implements the method described in Dabaghi & Der "
+         "Kiureghian (2018) \n\"Simulation of orthogonal horizontal "
+         "components of near-fault "
+         "motion for specified\nearthquake source and site characteristics\""));
+  //model_description_->setStyleSheet("QLabel { color : gray; }");
+
+  // Construct required layouts
+  QVBoxLayout* layout = new QVBoxLayout();
+  QHBoxLayout* seed_layout = new QHBoxLayout();
+  QHBoxLayout* truncate_layout = new QHBoxLayout();  
+  QHBoxLayout* parameters_layout = new QHBoxLayout();
+
+  // Add widgets to layouts and layouts to this
+  seed_layout->addWidget(use_seed_);
+  seed_layout->addWidget(seed_);
+  seed_layout->addStretch();
+  truncate_layout->addWidget(truncate_);
+  truncate_layout->addStretch();  
+  parameters_layout->addLayout(parameters_);
+  parameters_layout->addStretch();
+  layout->addWidget(model_description_);
+  layout->addLayout(parameters_layout);
+  layout->addLayout(truncate_layout);
+  layout->addLayout(seed_layout);
+  layout->addStretch();
+  this->setLayout(layout);
+
+  // Connect slots
+  connect(use_seed_, &QRadioButton::toggled, this,
+          &DabaghiDerKiureghianPulse::provideSeed);
+}
+
+bool DabaghiDerKiureghianPulse::outputToJSON(QJsonObject& jsonObject) {
+  bool result = true;
+
+  jsonObject.insert("faultType", faulting_->currentText());
+  jsonObject.insert("simulationType", sim_type_->currentText());
+
+  moment_magnitude_->outputToJSON(jsonObject, QString("momentMagnitude"));
+  depth_to_rupt_->outputToJSON(jsonObject, QString("depthToRupt"));
+  rupture_dist_->outputToJSON(jsonObject, QString("ruptureDist"));
+  vs30_->outputToJSON(jsonObject, QString("vs30"));
+  s_or_d_->outputToJSON(jsonObject, QString("sOrD"));
+  theta_or_phi_->outputToJSON(jsonObject, QString("thetaOrPhi"));
+
+  jsonObject.insert("truncate", truncate_->isChecked());
+
+  if (use_seed_->isChecked()) {
+    jsonObject.insert("seed", seed_->value());
+  } else {
+    jsonObject.insert("seed", "None");
+  }
+  
+  return result;
+}
+
+bool DabaghiDerKiureghianPulse::inputFromJSON(QJsonObject& jsonObject) {
+  bool result = true;
+
+  QString fault_type = jsonObject["faultType"].toString();
+  faulting_->setCurrentIndex(faulting_->findText(fault_type));
+  QString sim_type = jsonObject["simulationType"].toString();
+  sim_type_->setCurrentIndex(sim_type_->findText(sim_type));
+
+  moment_magnitude_->inputFromJSON(jsonObject, QString("momentMagnitude"));
+  depth_to_rupt_->inputFromJSON(jsonObject, QString("depthToRupt"));
+  rupture_dist_->inputFromJSON(jsonObject, QString("ruptureDist"));
+  vs30_->inputFromJSON(jsonObject, QString("vs30"));
+  s_or_d_->inputFromJSON(jsonObject, QString("sOrD"));
+  theta_or_phi_->inputFromJSON(jsonObject, QString("thetaOrPhi"));
+
+  if (jsonObject["truncate"].toBool()) {
+    truncate_->setChecked(true);
+  } else {
+    truncate_->setChecked(false);    
+  }
+
+  if (jsonObject.value("seed").isString()) {
+    use_seed_->setChecked(false);    
+  } else {
+    use_seed_->setChecked(true);
+    seed_->setValue(jsonObject.value("seed").toInt());    
+  }
+
+  return result;
+}
+
+void DabaghiDerKiureghianPulse::provideSeed(const bool& checked) {
+  if (checked) {
+    seed_->setEnabled(true);
+  } else {
+    seed_->setEnabled(false);
+    seed_->setValue(500);
+  }
+}


### PR DESCRIPTION
This pull request adds the following:
* Adds widget for generating synthetic motions using model developed by Dabaghi & Der Kiureghian (2018) - "Simulation of orthogonal horizontal components of near-fault motion for specified earthquake source and site characteristics"--this model is implemented in version 1.2.0 of `smelt` which already called in the latest version of `SimCenterBackendApplications`.